### PR TITLE
Modified the Dataset class

### DIFF
--- a/Spout.py
+++ b/Spout.py
@@ -200,7 +200,7 @@ class Spout:
         else:
             raise SubjectSetIdentificationError(subject_set_identifier)
 
-    def generate_manifest(self, manifest_filename, dataset_filename, overwrite_automatically = None, enable_strict_manifest = True):
+    def generate_manifest(self, manifest_filename, dataset_filename, overwrite_automatically = None, enable_strict_manifest = False):
         """
         Generates a manifest CSV file used to compile the information necessary to send over subjects to a subject set
         associated with the linked project.
@@ -227,14 +227,14 @@ class Spout:
             an existing manifest if it finds a manifest at the provided full path filename of the manifest CSV.
         """
 
-        dataset = CN_Dataset(dataset_filename,self.display_printouts, self.UI)
+        dataset = CN_Dataset(dataset_filename,require_uniform_fields=False, display_printouts=self.display_printouts, UI=self.UI)
         if(enable_strict_manifest):
             self.manifest = Defined_Manifest(dataset, manifest_filename, overwrite_automatically,display_printouts=self.display_printouts,UI=self.UI)
         else:
             self.manifest = Manifest(dataset, manifest_filename, overwrite_automatically,display_printouts=self.display_printouts,UI=self.UI)
 
     @classmethod
-    def generate_manifest_file(cls, manifest_filename, dataset_filename, overwrite_automatically = None, enable_strict_manifest = True, display_printouts = False, UI = None):
+    def generate_manifest_file(cls, manifest_filename, dataset_filename, overwrite_automatically = None, enable_strict_manifest = False, display_printouts = False, UI = None):
         """
         Generates a manifest CSV file used to compile the information necessary to send over subjects to a subject set
         associated with the linked project.
@@ -265,11 +265,11 @@ class Spout:
             an existing manifest if it finds a manifest at the provided full path filename of the manifest CSV.
         """
 
-        dataset = CN_Dataset(dataset_filename, display_printouts, UI)
+        dataset = CN_Dataset(dataset_filename, require_uniform_fields=False, display_printouts=display_printouts, UI=UI)
         if (enable_strict_manifest):
-            Defined_Manifest(dataset, manifest_filename, overwrite_automatically,display_printouts=display_printouts, UI=UI)
+            Defined_Manifest(dataset, manifest_filename, overwrite_automatically, display_printouts=display_printouts, UI=UI)
         else:
-            Manifest(dataset, manifest_filename, overwrite_automatically,display_printouts=display_printouts, UI=UI)
+            Manifest(dataset, manifest_filename, overwrite_automatically, display_printouts=display_printouts, UI=UI)
 
     def generate_subject_data_dicts(self,manifest_filename):
         """
@@ -413,7 +413,7 @@ class Spout:
             elif (isinstance(self.UI, UserInterface.UserInterface)):
                 self.UI.updateConsole("The existing manifest subjects have been published to Zooniverse.")
 
-    def upload_data_to_subject_set(self,subject_set, manifest_filename,dataset_filename, overwrite_automatically = None, enable_strict_manifest = True):
+    def upload_data_to_subject_set(self,subject_set, manifest_filename,dataset_filename, overwrite_automatically = None, enable_strict_manifest = False):
         """
         Uploads data from a dataset CSV, generates a manifest CSV, generates subjects from the manifest CSV, and then
         fills the subject set associated with the linked project on Zooniverse.

--- a/UserInterface.py
+++ b/UserInterface.py
@@ -4,16 +4,11 @@ Created on Mon Jun 13 10:14:59 2022
 
 @author: Noah Schapera
 """
-import io
-import logging
 import os
-import sys
 import threading
 import tkinter as tk
 from copy import copy
-from tkinter import ttk
 from tkinter import filedialog as fd
-from tkinter.messagebox import showinfo
 from tkinter.scrolledtext import ScrolledText
 import ZooniversePipeline
 import pickle
@@ -263,7 +258,7 @@ class UserInterface:
         ----------------------------------------------------
         |   help    |   submit   |            |            |
         ----------------------------------------------------
-        | manifest  |   upload   |    full    |            |
+        | manifest  |   upload   |    full    |  metadata  |
         ----------------------------------------------------
         |  console  |  console   |  console   |   console  |
         ----------------------------------------------------
@@ -362,7 +357,6 @@ class UserInterface:
         
         self.targetFile_entry.delete(0,tk.END)
         self.targetFile_entry.insert(0,filename)
-        
 
     def open_help_popup(self):
        '''
@@ -538,11 +532,11 @@ class UserInterface:
         return not isError
 
     def performState(self):
-        if(self.verifyInputs()):
-            metadata_dict = {"!GRID" : int(self.addGrid.get()), "!SCALE" : self.scaleFactor.get(), "WV_LINK" : None}
+        if (self.verifyInputs()):
+            metadata_dict = {"!GRID": int(self.addGrid.get()), "!SCALE": self.scaleFactor.get(), "WV_LINK": None}
 
             # Creates metadata-target.csv
-            ZooniversePipeline.mergeTargetsAndMetadata(self.targetFile.get(),metadata_dict,self.metadataTargetFile.get())
+            ZooniversePipeline.mergeTargetsAndMetadata(self.targetFile.get(), metadata_dict, self.metadataTargetFile.get())
 
             if (self.state.get() == 'f'):
                 ZooniversePipeline.fullPipeline(self)


### PR DESCRIPTION
Make a change to the Dataset class such that:

- Data/Metadata objects provided do not all need to be uniform, unless require_uniform_fields is set to False.

- Non-uniform Data/Metadata, which are only valid if there is extra fields after the existing fields (not mismatched fields, etc.), will fill themselves with the extra fields and set their values as None.

-Allow dataset objects to be created without any metadata (if no metadata objects are provided, it will create a default empty private metadata object so it can still function)

Note: Variable number of data fields means that the master_header.txt won't be particularly useful unless we can somehow fix the number of frames we could possibly receive.