### PR TITLE
Added the ability to detect partial cutouts

### DIFF
--- a/Spout.py
+++ b/Spout.py
@@ -227,7 +227,7 @@ class Spout:
             an existing manifest if it finds a manifest at the provided full path filename of the manifest CSV.
         """
 
-        dataset = CN_Dataset(dataset_filename,require_uniform_fields=False, display_printouts=self.display_printouts, UI=self.UI)
+        dataset = CN_Dataset(dataset_filename, ignore_partial_cutouts=True, require_uniform_fields=False, display_printouts=self.display_printouts, UI=self.UI)
         if(enable_strict_manifest):
             self.manifest = Defined_Manifest(dataset, manifest_filename, overwrite_automatically,display_printouts=self.display_printouts,UI=self.UI)
         else:
@@ -265,7 +265,7 @@ class Spout:
             an existing manifest if it finds a manifest at the provided full path filename of the manifest CSV.
         """
 
-        dataset = CN_Dataset(dataset_filename, require_uniform_fields=False, display_printouts=display_printouts, UI=UI)
+        dataset = CN_Dataset(dataset_filename, ignore_partial_cutouts=True, require_uniform_fields=False, display_printouts=display_printouts, UI=UI)
         if (enable_strict_manifest):
             Defined_Manifest(dataset, manifest_filename, overwrite_automatically, display_printouts=display_printouts, UI=UI)
         else:


### PR DESCRIPTION
Added the ability for Zooniverse_Datasets to detect partial cutouts and remove them automatically. The removed targets are sent to an "ignored-targets.csv" file.

Additionally, the structure of Zooniverse_Dataset was adjusted so that any child class of Zooniverse_Dataset will use its own "generateDataAndMetadataLists" function, so that specific project functionality can be implemented on a per-project basis in the future.